### PR TITLE
Add GPU usage options and script improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,78 @@
 # YOLOv8-PipeCircle
-Implementing pipe circle detection using YOLOv8 base structure
+
+This repository provides a basic setup for training and running inference with a YOLOv8 object detection model using PyTorch. Pretrained weights are downloaded automatically by the [Ultralytics](https://github.com/ultralytics/ultralytics) package.
+
+## Setup
+
+Install PyTorch with GPU support following the [official instructions](https://pytorch.org/get-started/locally/)
+for your CUDA version. After PyTorch is installed, install the remaining
+dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Dataset
+
+Place your dataset in the `datasets/` directory using the standard YOLO format and create a YAML configuration file describing the dataset (see Ultralytics documentation for details).
+
+## Training
+
+### Bounding Box Model
+
+Run training with:
+
+```bash
+python train.py --data datasets/your_dataset.yaml --weights yolov8n.pt --epochs 100
+```
+For example, to train on the first GPU:
+```bash
+python train.py --data datasets/your_dataset.yaml --device 0
+```
+
+The training script detects a CUDA capable device automatically. Use the
+`--device` option to explicitly choose a device (e.g. `0` for the first GPU or
+`cpu`).
+
+Use the `--freeze` argument to freeze the first N layers of the network when fine‑tuning.
+
+### Bounding Circle Model
+
+Phase 2 introduces a modified YOLO head that predicts circle center `(x, y)` and radius `r` instead of a bounding box. Train this model with:
+
+```bash
+python train_circle.py --data datasets/your_dataset.yaml --weights yolov8n.pt --epochs 100
+```
+
+As with the box model, training uses the GPU when available. Specify a
+particular device with `--device` if needed.
+
+## Inference
+
+After training, run inference on images with:
+
+```bash
+python infer.py --weights path/to/best.pt --source path/to/images --save
+```
+
+Inference also defaults to the first CUDA device when available. Pass
+`--device cpu` to force CPU mode.
+Example using a GPU:
+```bash
+python infer.py --weights path/to/best.pt --source images/ --device 0
+```
+
+Results will be printed to the console and optionally saved alongside the source images.
+
+For the circle model use:
+
+```bash
+python infer_circle.py --weights circle_trained.pt --data datasets/your_dataset.yaml --source path/to/image.jpg --save
+```
+
+The `--device` option is available here as well.
+Example:
+```bash
+python infer_circle.py --weights circle_trained.pt --data datasets/your_dataset.yaml --source img.jpg --device 0
+```
+

--- a/circle_dataset.py
+++ b/circle_dataset.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+from typing import List, Tuple
+import yaml
+import torch
+from torch.utils.data import Dataset
+from PIL import Image
+from torchvision import transforms
+
+
+class CircleDataset(Dataset):
+    """Dataset for training circle detection in YOLO format."""
+
+    def __init__(self, data_yaml: str, split: str = "train", img_size: int = 640):
+        cfg = yaml.safe_load(open(data_yaml, 'r'))
+        path = Path(cfg.get('path', '.'))
+        self.img_dir = path / cfg.get(f'{split}', 'images/' + split)
+        self.label_dir = path / 'labels' / split
+        self.img_files = sorted(self.img_dir.glob('*.*'))
+        self.transform = transforms.Compose([
+            transforms.Resize((img_size, img_size)),
+            transforms.ToTensor(),
+        ])
+
+    def __len__(self) -> int:
+        return len(self.img_files)
+
+    def __getitem__(self, idx: int) -> Tuple[torch.Tensor, torch.Tensor]:
+        img_path = self.img_files[idx]
+        label_path = self.label_dir / (img_path.stem + '.txt')
+        img = Image.open(img_path).convert('RGB')
+        img = self.transform(img)
+        targets = []
+        if label_path.exists():
+            for line in open(label_path):
+                cls, x, y, r = map(float, line.split())
+                targets.append([cls, x, y, r])
+        targets = torch.tensor(targets, dtype=torch.float32)
+        return img, targets
+
+    @staticmethod
+    def collate_fn(batch: List[Tuple[torch.Tensor, torch.Tensor]]):
+        imgs, targets = zip(*batch)
+        imgs = torch.stack(imgs)
+        return imgs, targets

--- a/circle_loss.py
+++ b/circle_loss.py
@@ -1,0 +1,27 @@
+import torch
+from torch import nn
+import torch.nn.functional as F
+
+
+class CircleLoss(nn.Module):
+    """Simple loss for circle detection."""
+
+    def __init__(self, box_weight: float = 1.0, cls_weight: float = 1.0):
+        super().__init__()
+        self.box_weight = box_weight
+        self.cls_weight = cls_weight
+
+    def forward(self, preds, targets, nc: int):
+        circles, scores = preds.split([3, nc], 1)
+        batch_loss = 0.0
+        n = 0
+        for i, t in enumerate(targets):
+            if len(t):
+                pc = circles[i][:, None, :].expand(-1, len(t), -1)
+                tc = t[:, 1:4].to(pc.device)
+                cls_t = t[:, 0].long().to(pc.device)
+                l_box = F.l1_loss(pc[:, :, :3], tc, reduction='none').mean()
+                l_cls = F.cross_entropy(scores[i], cls_t, reduction='mean') if scores[i].numel() else 0.0
+                batch_loss += self.box_weight * l_box + self.cls_weight * l_cls
+                n += 1
+        return batch_loss / max(n, 1)

--- a/circle_model.py
+++ b/circle_model.py
@@ -1,0 +1,93 @@
+import math
+from typing import List, Tuple
+import torch
+from torch import nn
+from ultralytics import YOLO
+from ultralytics.nn.modules.conv import Conv
+from ultralytics.nn.modules.head import Detect
+from ultralytics.nn.modules.block import DFL
+from ultralytics.utils.tal import make_anchors
+
+
+class CircleDetect(nn.Module):
+    """YOLO detection head that predicts circle center and radius."""
+
+    dynamic = False
+    export = False
+    format = None
+    end2end = False
+    max_det = 300
+    shape = None
+    anchors = torch.empty(0)
+    strides = torch.empty(0)
+    legacy = False
+
+    def __init__(self, nc: int = 80, ch: Tuple = ()):  # channels from previous layer
+        super().__init__()
+        self.nc = nc
+        self.nl = len(ch)
+        self.reg_max = 16
+        self.no = nc + self.reg_max * 3
+        self.stride = torch.zeros(self.nl)
+        c2, c3 = max((16, ch[0] // 4, self.reg_max * 3)), max(ch[0], min(self.nc, 100))
+        self.cv2 = nn.ModuleList(
+            nn.Sequential(Conv(x, c2, 3), Conv(c2, c2, 3), nn.Conv2d(c2, 3 * self.reg_max, 1)) for x in ch
+        )
+        self.cv3 = nn.ModuleList(
+            nn.Sequential(Conv(x, c3, 3), Conv(c3, c3, 3), nn.Conv2d(c3, self.nc, 1)) for x in ch
+        )
+        self.dfl = DFL(self.reg_max) if self.reg_max > 1 else nn.Identity()
+
+    def forward(self, x: List[torch.Tensor]):
+        for i in range(self.nl):
+            x[i] = torch.cat((self.cv2[i](x[i]), self.cv3[i](x[i])), 1)
+        if self.training:
+            return x
+        y = self._inference(x)
+        return y if self.export else (y, x)
+
+    def _inference(self, x: List[torch.Tensor]) -> torch.Tensor:
+        shape = x[0].shape
+        x_cat = torch.cat([xi.view(shape[0], self.no, -1) for xi in x], 2)
+        if self.format != "imx" and (self.dynamic or self.shape != shape):
+            self.anchors, self.strides = (t.transpose(0, 1) for t in make_anchors(x, self.stride, 0.5))
+            self.shape = shape
+        circle, cls = x_cat.split((self.reg_max * 3, self.nc), 1)
+        dcircle = self.decode_bboxes(self.dfl(circle), self.anchors.unsqueeze(0)) * self.strides
+        if self.export and self.format == "imx":
+            return dcircle.transpose(1, 2), cls.sigmoid().permute(0, 2, 1)
+        return torch.cat((dcircle, cls.sigmoid()), 1)
+
+    def decode_bboxes(self, circles: torch.Tensor, anchors: torch.Tensor) -> torch.Tensor:
+        """Decode circle predictions relative to anchor centers."""
+        x = circles[:, 0] + anchors[:, 0]
+        y = circles[:, 1] + anchors[:, 1]
+        r = circles[:, 2].exp()
+        return torch.stack((x, y, r), 1)
+
+    @staticmethod
+    def postprocess(preds: torch.Tensor, max_det: int, nc: int = 80) -> torch.Tensor:
+        batch_size, anchors, _ = preds.shape
+        circles, scores = preds.split([3, nc], dim=-1)
+        index = scores.amax(dim=-1).topk(min(max_det, anchors))[1].unsqueeze(-1)
+        circles = circles.gather(dim=1, index=index.repeat(1, 1, 3))
+        scores = scores.gather(dim=1, index=index.repeat(1, 1, nc))
+        scores, index = scores.flatten(1).topk(min(max_det, anchors))
+        i = torch.arange(batch_size)[..., None]
+        return torch.cat([circles[i, index // nc], scores[..., None], (index % nc)[..., None].float()], dim=-1)
+
+
+def load_yolov8_circle(weights: str = "yolov8n.pt", nc: int = 80) -> YOLO:
+    """Load a pretrained YOLOv8 model and replace its head with CircleDetect."""
+    model = YOLO(weights)
+    head = model.model.model[-1]
+    ch = [m[0].conv.in_channels for m in head.cv2]
+    circle_head = CircleDetect(nc=nc, ch=ch)
+    circle_head.stride = head.stride
+
+    # Copy classification weights
+    for src, dst in zip(head.cv3, circle_head.cv3):
+        dst.load_state_dict(src.state_dict())
+
+    model.model.model[-1] = circle_head
+    return model

--- a/infer.py
+++ b/infer.py
@@ -1,0 +1,25 @@
+import argparse
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Run inference with a trained YOLOv8 model")
+    parser.add_argument('--weights', type=str, required=True, help='Path to model weights')
+    parser.add_argument('--source', type=str, required=True, help='Image or directory to run inference on')
+    parser.add_argument('--img-size', type=int, default=640, help='Image size')
+    parser.add_argument('--save', action='store_true', help='Save predictions to file')
+    parser.add_argument('--device', type=str, default='cuda', help='Computation device')
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    from ultralytics import YOLO
+    model = YOLO(args.weights)
+    results = model.predict(source=args.source, imgsz=args.img_size,
+                           save=args.save, device=args.device)
+    for r in results:
+        boxes = r.boxes
+        print(boxes)
+
+
+if __name__ == '__main__':
+    main()

--- a/infer_circle.py
+++ b/infer_circle.py
@@ -1,0 +1,47 @@
+import argparse
+import numpy as np
+import yaml
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Inference with circle detection model")
+    parser.add_argument('--weights', type=str, required=True, help='Trained weights')
+    parser.add_argument('--data', type=str, required=True, help='Dataset YAML for class names')
+    parser.add_argument('--source', type=str, required=True, help='Image path')
+    parser.add_argument('--img-size', type=int, default=640)
+    parser.add_argument('--save', action='store_true')
+    parser.add_argument('--device', type=str, default='cuda', help='Computation device')
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    from ultralytics.utils.plotting import Annotator
+    from circle_model import load_yolov8_circle
+    from PIL import Image
+    import torch
+
+    cfg = yaml.safe_load(open(args.data))
+    nc = cfg['nc']
+    names = cfg.get('names', list(range(nc)))
+    model = load_yolov8_circle(args.weights, nc)
+    device = torch.device(args.device if torch.cuda.is_available() or args.device == 'cpu' else 'cpu')
+    model.model.to(device)
+    img = Image.open(args.source).convert('RGB')
+    img_resized = img.resize((args.img_size, args.img_size))
+    img_tensor = torch.tensor(np.array(img_resized)).permute(2, 0, 1).float() / 255.0
+    pred = model.model(img_tensor.unsqueeze(0).to(device))[0]
+    annotator = Annotator(img)
+    for c, score, cls in pred:
+        x, y, r = c
+        annotator.circle((float(x), float(y)), float(r), label=names[int(cls)], color=(255,0,0))
+    if args.save:
+        out = args.source.replace('.', '_pred.')
+        annotator.result().save(out)
+        print(f"Saved to {out}")
+    else:
+        annotator.result().show()
+
+
+if __name__ == '__main__':
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,13 @@
+torch==2.3.0
+torchvision==0.18.0
+ultralytics==8.3.170
+opencv-python-headless
+pillow
+numpy
+pyyaml
+requests
+tqdm
+pandas
+scipy
+matplotlib
+

--- a/train.py
+++ b/train.py
@@ -1,0 +1,24 @@
+import argparse
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Train YOLOv8 on a custom dataset")
+    parser.add_argument('--data', type=str, required=True, help='Path to dataset YAML')
+    parser.add_argument('--weights', type=str, default='yolov8n.pt', help='Pretrained weights')
+    parser.add_argument('--epochs', type=int, default=100, help='Training epochs')
+    parser.add_argument('--batch', type=int, default=16, help='Batch size')
+    parser.add_argument('--img-size', type=int, default=640, help='Image size')
+    parser.add_argument('--freeze', type=int, default=None, help='Number of layers to freeze')
+    parser.add_argument('--device', type=str, default='cuda', help='Computation device')
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    from ultralytics import YOLO
+    model = YOLO(args.weights)
+    model.train(data=args.data, epochs=args.epochs, imgsz=args.img_size,
+                batch=args.batch, freeze=args.freeze, device=args.device)
+
+
+if __name__ == '__main__':
+    main()

--- a/train_circle.py
+++ b/train_circle.py
@@ -1,0 +1,50 @@
+import argparse
+import yaml
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Train YOLOv8 circle model")
+    parser.add_argument('--data', type=str, required=True, help='Dataset YAML')
+    parser.add_argument('--weights', type=str, default='yolov8n.pt', help='Pretrained weights')
+    parser.add_argument('--epochs', type=int, default=100)
+    parser.add_argument('--batch', type=int, default=16)
+    parser.add_argument('--img-size', type=int, default=640)
+    parser.add_argument('--device', type=str, default='cuda', help='Computation device')
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    from torch.utils.data import DataLoader
+    import torch
+    from circle_model import load_yolov8_circle
+    from circle_dataset import CircleDataset
+    from circle_loss import CircleLoss
+
+    cfg = yaml.safe_load(open(args.data))
+    nc = cfg['nc']
+    model = load_yolov8_circle(args.weights, nc)
+    device = torch.device(args.device if torch.cuda.is_available() or args.device == 'cpu' else 'cpu')
+    model.model.to(device)
+    dataset = CircleDataset(args.data, 'train', img_size=args.img_size)
+    loader = DataLoader(dataset, batch_size=args.batch, shuffle=True, collate_fn=CircleDataset.collate_fn)
+    optimizer = torch.optim.Adam(model.model.parameters(), lr=1e-4)
+    criterion = CircleLoss()
+
+    model.model.train()
+    for epoch in range(args.epochs):
+        for imgs, targets in loader:
+            imgs = imgs.to(device)
+            preds = model.model(imgs)[0]
+            loss = criterion(preds, targets, nc)
+            optimizer.zero_grad()
+            loss.backward()
+            optimizer.step()
+        print(f"Epoch {epoch+1}/{args.epochs} loss: {loss.item():.4f}")
+
+    model.model.eval()
+    model.model.save('circle_trained.pt')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- update requirements for GPU-enabled torch
- add CUDA installation notes and examples in README
- add `--device` option across training and inference scripts
- load heavy libraries inside main for better `--help` support
- move data to GPU in custom circle training

## Testing
- `python train.py --help`
- `python infer.py --help`
- `python train_circle.py --help`
- `python infer_circle.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68878df0db4c83319c2d4c1dbd45e49f